### PR TITLE
Add cherry blossom theme with falling petal animation

### DIFF
--- a/tame/app.py
+++ b/tame/app.py
@@ -32,6 +32,7 @@ from tame.ui.events import (
 from tame.ui.keys.manager import KeybindManager
 from tame.ui.themes.manager import ThemeManager
 from tame.ui.widgets import (
+    CherryBlossomPetals,
     CommandPalette,
     ConfirmDialog,
     DiffViewer,
@@ -343,6 +344,7 @@ class TAMEApp(App):
                 yield SessionSearchBar()
         yield StatusBar()
         yield ToastOverlay()
+        yield CherryBlossomPetals()
 
     def on_mount(self) -> None:
         loop = asyncio.get_running_loop()
@@ -350,6 +352,12 @@ class TAMEApp(App):
         self.call_later(self._restore_tmux_sessions_async)
         self._start_resource_poll()
         self._start_tmux_health_check()
+        # Activate cherry blossom petals if starting with that theme.
+        if self._theme_manager.current == "cherry_blossom":
+            try:
+                self.query_one(CherryBlossomPetals).display = True
+            except Exception:
+                pass
         log.info("TAME started")
 
     # ------------------------------------------------------------------
@@ -639,6 +647,12 @@ class TAMEApp(App):
             sidebar = self.query_one(SessionSidebar)
             sidebar.styles.background = sbg
             sidebar.styles.color = sfg
+        except Exception:
+            pass
+        # Toggle cherry blossom petal animation.
+        try:
+            petals = self.query_one(CherryBlossomPetals)
+            petals.display = new_theme == "cherry_blossom"
         except Exception:
             pass
         log.info("Switched theme to '%s'", new_theme)

--- a/tame/ui/themes/builtin/cherry_blossom.tcss
+++ b/tame/ui/themes/builtin/cherry_blossom.tcss
@@ -1,0 +1,110 @@
+/* TAME Cherry Blossom Theme */
+
+Screen {
+    background: #fff0f5;
+    color: #4a3040;
+}
+
+#header-bar {
+    dock: top;
+    height: 1;
+    background: #d4678e;
+    color: #ffffff;
+    padding: 0 1;
+}
+
+#sidebar {
+    width: 28;
+    background: #ffe4ec;
+    border-right: solid #f0b8cc;
+}
+
+#sidebar-search {
+    margin: 0 1;
+    height: 1;
+}
+
+#session-list {
+    background: #ffe4ec;
+}
+
+.session-item {
+    padding: 0 1;
+    height: 1;
+}
+
+.session-item:hover {
+    background: #ffd0dc;
+}
+
+.session-item.--highlight {
+    background: #ffb6c8;
+}
+
+.session-item.status-active {
+    color: #5a9e5a;
+}
+
+.session-item.status-idle {
+    color: #b0909e;
+}
+
+.session-item.status-waiting {
+    color: #d4a058;
+}
+
+.session-item.status-error {
+    color: #c44569;
+}
+
+.session-item.status-done {
+    color: #5a9e5a;
+}
+
+.session-item.status-paused {
+    color: #b0909e;
+}
+
+#new-session-btn {
+    margin: 0 1;
+    height: 1;
+    background: #f0c0d0;
+    color: #4a3040;
+}
+
+#main-panel {
+    background: #fff0f5;
+}
+
+#session-header {
+    height: 2;
+    background: #ffe4ec;
+    padding: 0 1;
+    color: #8a607a;
+    border-bottom: solid #f0b8cc;
+}
+
+#session-viewer {
+    background: #fff0f5;
+    color: #4a3040;
+}
+
+#input-area {
+    dock: bottom;
+    height: 3;
+    background: #ffe4ec;
+    border-top: solid #f0b8cc;
+    padding: 0 1;
+}
+
+#status-bar {
+    dock: bottom;
+    height: 1;
+    background: #d4678e;
+    color: #ffffff;
+    padding: 0 1;
+}
+
+#toast-overlay {
+    layer: overlay;
+}

--- a/tame/ui/themes/manager.py
+++ b/tame/ui/themes/manager.py
@@ -16,6 +16,7 @@ BUILTIN_THEMES = [
     "gruvbox",
     "solarized_dark",
     "solarized_light",
+    "cherry_blossom",
 ]
 
 # Colors for widgets that actually exist in the app.
@@ -76,6 +77,13 @@ THEME_COLORS: dict[str, dict[str, tuple[str, str]]] = {
         "sidebar": ("#eee8d5", "#657b83"),
         "viewer": ("#fdf6e3", "#657b83"),
         "status": ("#268bd2", "#fdf6e3"),
+    },
+    "cherry_blossom": {
+        "screen": ("#fff0f5", "#4a3040"),
+        "header": ("#d4678e", "#ffffff"),
+        "sidebar": ("#ffe4ec", "#4a3040"),
+        "viewer": ("#fff0f5", "#4a3040"),
+        "status": ("#d4678e", "#ffffff"),
     },
 }
 

--- a/tame/ui/widgets/__init__.py
+++ b/tame/ui/widgets/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from .cherry_blossom_petals import CherryBlossomPetals
 from .command_palette import CommandPalette
 from .confirm_dialog import ConfirmDialog
 from .diff_viewer import DiffViewer
@@ -18,6 +19,7 @@ from .status_bar import StatusBar
 from .toast_overlay import ToastOverlay
 
 __all__ = [
+    "CherryBlossomPetals",
     "CommandPalette",
     "ConfirmDialog",
     "DiffViewer",

--- a/tame/ui/widgets/cherry_blossom_petals.py
+++ b/tame/ui/widgets/cherry_blossom_petals.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import random
+
+from rich.segment import Segment
+from rich.style import Style
+from textual.strip import Strip
+from textual.timer import Timer
+from textual.widget import Widget
+
+
+class CherryBlossomPetals(Widget):
+    """Animated falling cherry blossom petals overlay.
+
+    Only visible when the cherry_blossom theme is active.
+    Renders sparse ASCII petals drifting downward across the screen.
+    """
+
+    DEFAULT_CSS = """
+    CherryBlossomPetals {
+        layer: overlay;
+        width: 1fr;
+        height: 1fr;
+        display: none;
+    }
+    """
+
+    PETAL_CHARS = ("*", ".", "~", "*", ".", "°")
+    PETAL_COLORS = ("#d4678e", "#e891a8", "#ffb6d9", "#ffc9dd", "#f0a0b8")
+
+    can_focus = False
+
+    def __init__(self) -> None:
+        super().__init__(id="cherry-blossom-petals")
+        # Each petal: [row_float, col_int, char, color_hex, speed_float]
+        self._petals: list[list] = []
+        self._animation_timer: Timer | None = None
+
+    def on_mount(self) -> None:
+        self._animation_timer = self.set_interval(0.15, self._tick)
+
+    def _tick(self) -> None:
+        if not self.display:
+            return
+
+        height = self.size.height
+        width = self.size.width
+        if height <= 0 or width <= 0:
+            return
+
+        # Move existing petals downward with slight horizontal drift.
+        surviving: list[list] = []
+        for petal in self._petals:
+            row, col, char, color, speed = petal
+            new_row = row + speed
+            new_col = col + random.choice([-1, 0, 0, 0, 1])
+            if new_row < height and 0 <= new_col < width:
+                surviving.append([new_row, new_col, char, color, speed])
+
+        # Spawn a new petal occasionally (keep density low).
+        if random.random() < 0.35:
+            col = random.randint(0, max(0, width - 1))
+            char = random.choice(self.PETAL_CHARS)
+            color = random.choice(self.PETAL_COLORS)
+            speed = random.choice([0.5, 1.0, 1.0, 1.5])
+            surviving.append([0.0, col, char, color, speed])
+
+        self._petals = surviving
+        self.refresh()
+
+    def render_line(self, y: int) -> Strip:
+        """Render a single line of the petal overlay."""
+        width = self.size.width
+        if width <= 0:
+            return Strip.blank(width)
+
+        # Collect petals on this row.
+        row_petals: dict[int, tuple[str, str]] = {}
+        for petal in self._petals:
+            row, col, char, color, _speed = petal
+            if int(row) == y and 0 <= int(col) < width:
+                row_petals[int(col)] = (char, color)
+
+        if not row_petals:
+            return Strip.blank(width)
+
+        # Build segments: spaces for empty cells, styled chars for petals.
+        segments: list[Segment] = []
+        blank = Style()
+        i = 0
+        while i < width:
+            if i in row_petals:
+                char, color = row_petals[i]
+                segments.append(Segment(char, Style(color=color, bold=True)))
+                i += 1
+            else:
+                # Accumulate consecutive blank spaces.
+                start = i
+                while i < width and i not in row_petals:
+                    i += 1
+                segments.append(Segment(" " * (i - start), blank))
+
+        return Strip(segments, width)


### PR DESCRIPTION
## Summary
- Adds a new **cherry_blossom** theme with a very light pink (lavender blush) background, rose-pink header/status bar, and soft pink sidebar
- Includes an animated overlay of falling ASCII cherry blossom petals (`*`, `.`, `~`, `°`) that drift downward across the screen in various shades of pink
- Petal animation automatically activates only when the cherry_blossom theme is selected, and deactivates when switching to any other theme

## New files
- `tame/ui/themes/builtin/cherry_blossom.tcss` — theme color definitions
- `tame/ui/widgets/cherry_blossom_petals.py` — animated petal overlay widget

## Modified files
- `tame/ui/themes/manager.py` — registered theme in `BUILTIN_THEMES` and `THEME_COLORS`
- `tame/ui/widgets/__init__.py` — exported `CherryBlossomPetals`
- `tame/app.py` — added petal widget to `compose()`, toggled on theme switch and mount

## Test plan
- [x] All 268 existing tests pass
- [ ] Launch app, cycle themes with Ctrl+T to reach cherry_blossom
- [ ] Verify light pink color palette renders correctly
- [ ] Verify falling petal animation appears and petals drift downward
- [ ] Switch to another theme and verify petals disappear
- [ ] Switch back to cherry_blossom and verify petals reappear